### PR TITLE
fix: pagination bug

### DIFF
--- a/src/pages/Repository/index.js
+++ b/src/pages/Repository/index.js
@@ -69,7 +69,7 @@ export default class Repository extends Component {
   };
 
   handleFilterClick = async filterIndex => {
-    await this.setState({ filterIndex });
+    await this.setState({ filterIndex, page: 1 });
     this.loadIssues();
   };
 


### PR DESCRIPTION
If the user decides to change the issues filter (e.g. "all" to "open") and the current page (e.g. "all" 6) is higher than the next issues filter page (e.g. "open" max 5 pages) this will return an empty page for the user as if the research turns out null. This change forces a reset in pagination.