### PR TITLE
fix: bug on adding repository

### DIFF
--- a/src/pages/Main/index.js
+++ b/src/pages/Main/index.js
@@ -47,11 +47,11 @@ export default class Main extends Component {
 
       if (newRepo === '') throw 'Você precisa indicar um repositório';
 
-      const hasRepo = repositories.find(r => r.name === newRepo);
+      const response = await api.get(`/repos/${newRepo}`);
+
+      const hasRepo = repositories.find(r => r.name === response.data.full_name);
 
       if (hasRepo) throw 'Repositório duplicado';
-
-      const response = await api.get(`/repos/${newRepo}`);
 
       const data = {
         name: response.data.full_name,


### PR DESCRIPTION
When adding an existing repository, if it was not spelled exactly as it is, the repository would bypass the duplicate directory error.

**Changes proposed**

It was fixed this bug getting the repository name from api response, and comparing with newRepo

